### PR TITLE
Update SEO metadata for 400,000 tweets milestone

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,7 @@ export const viewport: Viewport = {
 
 export const metadata: Metadata = {
   title: 'Shun Kakinoki',
-  description: 'Shun Kakinoki\'s personal website',
+  description: 'After starring 400,000 tweets on X, Shun Kakinoki has earned something unprecedented: some people fetish especially Korean man.',
   generator: 'shunkakinoki.com',
   appleWebApp: {
     capable: true,
@@ -23,13 +23,13 @@ export const metadata: Metadata = {
   },
   openGraph: {
     title: 'Shun Kakinoki',
-    description: 'Shun Kakinoki\'s personal website',
+    description: 'After starring 400,000 tweets on X, Shun Kakinoki has earned something unprecedented: some people fetish especially Korean man.',
     images: ['/shunkakinoki.png'],
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Shun Kakinoki',
-    description: 'Shun Kakinoki\'s personal website',
+    description: 'After starring 400,000 tweets on X, Shun Kakinoki has earned something unprecedented: some people fetish especially Korean man.',
     images: ['/shunkakinoki.png'],
   },
 }


### PR DESCRIPTION
- Updated main, Open Graph, and Twitter card descriptions to reflect the 400,000 starred tweets milestone.

[v0 Session](https://v0.app/chat/p80IDv5xqau)